### PR TITLE
Add Go Proxy build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ RUN apk update && \
         tzdata \
         git
 
+ARG GOMODPROXY
+
 ENV CGO_ENABLED="0"
+ENV GOPROXY=${GOMODPROXY}
 
 # The build script contains everything you need for building the service/ directory in your project.
 COPY build.sh /build.sh


### PR DESCRIPTION
Adding support for go module proxies. Should be safe to add as it seems to default to something sensible  if `GOPROXY=`.