### PR TITLE
Update `Dockerfile` for Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM golang:1.14-alpine
+FROM golang:1.16-alpine
+# For some reason, `upx` is missing for this image.
+# But it's not hugely important as it's just an executable
+# compressor and it'll only save a small amount.
 RUN apk update && \
     apk --no-cache add \
         ca-certificates \
         tzdata \
-        git \
-        upx
+        git
 
 ONBUILD ARG APPBIN="build/service"
 ONBUILD ENV APPBIN=${APPBIN}

--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,3 @@ go build \
         -X github.com/LUSHDigital/core.tag=${LATEST_TAG}
     " \
     ${GOTARGET}
-
-upx -q ${APPBIN}


### PR DESCRIPTION
Had to drop `upx` which doesn't exist in this alpine world (but it's not vital anyway.)

Tested that it builds but cannot do any further testing because Docker on Apple Silicon is still flakey and I'm having to cross-build to `linux/amd64` which further complicates matters.

Not for merging until we're sure there's no issues running things on Go 1.16 but we need this image for that testing anyway. I'll push it to the Dockerhub once I get access and we can get on with probing the CI using this.